### PR TITLE
Allow for turning off the additional lance dialogue on mission start

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -8,6 +8,7 @@
   },
   "AdditionalLances": {
     "Enable": true,
+    "Dialogue": true,
     "SkullValueMatters": true,
     "BasedOnVisibleSkullValue": true,
     "UseGeneralProfileForSkirmish": true,

--- a/src/Core/EncounterLogic/BatchedLogic/AddEmployerLanceBatch.cs
+++ b/src/Core/EncounterLogic/BatchedLogic/AddEmployerLanceBatch.cs
@@ -22,14 +22,16 @@ namespace MissionControl.Logic {
         encounterRules.EncounterLogic.Add(new SpawnLanceMembersAroundTarget(encounterRules, spawnerName, orientationTargetKey,
           lookDirection, minDistance, maxDistance));
 
-        encounterRules.EncounterLogic.Add(new AddDialogueChunk(
-          ChunkLogic.DIALOGUE_ADDITIONAL_LANCE_ALLY_START_GUID,
-          "AdditionalLanceAllyStart",
-          "Start Conversation For Additional Lance Ally",
-          lanceGuid
-          // "DialogBucketDef_Universal_KillConfirmed"
-        ));
-        encounterRules.EncounterLogic.Add(new DialogTrigger(MessageCenterMessageType.OnEncounterIntroComplete, ChunkLogic.DIALOGUE_ADDITIONAL_LANCE_ALLY_START_GUID));
+        if (Main.Settings.AdditionalLanceSettings.UseDialogue) {
+          encounterRules.EncounterLogic.Add(new AddDialogueChunk(
+            ChunkLogic.DIALOGUE_ADDITIONAL_LANCE_ALLY_START_GUID,
+            "AdditionalLanceAllyStart",
+            "Start Conversation For Additional Lance Ally",
+            lanceGuid
+            // "DialogBucketDef_Universal_KillConfirmed"
+          ));
+          encounterRules.EncounterLogic.Add(new DialogTrigger(MessageCenterMessageType.OnEncounterIntroComplete, ChunkLogic.DIALOGUE_ADDITIONAL_LANCE_ALLY_START_GUID));
+        }
 
         encounterRules.ObjectReferenceQueue.Add(spawnerName);
     }

--- a/src/Core/Settings/AdditionalLanceSettings.cs
+++ b/src/Core/Settings/AdditionalLanceSettings.cs
@@ -5,7 +5,10 @@ using Newtonsoft.Json;
 namespace MissionControl.Config {
 	public class AdditionalLanceSettings {
 		[JsonProperty("Enable")]
-		public bool Enable { get; set; } = true;                                                                                                                                                                                                                                                                                                                                                           
+		public bool Enable { get; set; } = true;
+
+		[JsonProperty("UseDialogue")]
+		public bool UseDialogue { get; set; } = true;
 
 		[JsonProperty("SkullValueMatters")]
 		public bool SkullValueMatters { get; set; } = true;


### PR DESCRIPTION
Some players might want to not be spammed by the dialogue at the start of a contract when an ally has spawned (even if I do think it's cool).

This adds an option in the `settings.json` to turn the dialogue off.