### PR TITLE
Update settings.json

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -19,7 +19,7 @@
   "AdditionalLances": {
     "Enable": true,
     "ExcludeContractTypes": ["SoloDuel", "DuoDuel"],
-    "IsPrimaryObjectiveIn": ["SimpleBattle", "ThreeWayBattle"],
+    "IsPrimaryObjectiveIn": ["SimpleBattle", "CaptureBase"],
     "HideObjective": true,
     "ShowObjectiveOnLanceDetected": true,
     "AlwaysDisplayHiddenObjectiveIfPrimary": false,


### PR DESCRIPTION
Several Three Way Battle contracts are built around an option to extract after completing a Primary objective. Creating additional Primaries is problematic. CaptureBase is built around pacifying and holding an area. It probably shouldn't end abruptly while enemies are on the field.