### PR TITLE
Added a dev mode to show certain logic errors more clearly

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -149,6 +149,7 @@
     "SearchType": "ShallowFromModsFolder"
   },
   "CustomContractTypes": {
+    "DeveloperMode": true,
     "Accessibility": {
       "AllowCameraShake": true
     }

--- a/src/Core/EncounterResults/State/SetStatusResult.cs
+++ b/src/Core/EncounterResults/State/SetStatusResult.cs
@@ -16,10 +16,19 @@ namespace MissionControl.Result {
           Main.LogDebug($"[SetStatusResult] Avoiding '{encounterGameLogic.gameObject.name}' due to it not being an active chunk in the contract overrides");
         } else {
           Main.LogDebug($"[SetStatusResult] Setting '{encounterGameLogic.gameObject.name}' state '{Status}'");
+          Main.LogDebug($"[SetStatusResult] Object is '{encounterGameLogic}' with state '{encounterGameLogic.GetState()}'");
 
+          if (encounterGameLogic is EncounterChunkGameLogic encounterChunkGameLogic && encounterChunkGameLogic.IsState(EncounterObjectStatus.Finished)) {
+            // If the encounter is finished it should not be reactivated - check if there are any objectives under it that are Ignored
+            Main.LogDeveloperWarning($"[SetStatusResult] Setting the Chunk '{encounterGameLogic.gameObject.name}' Encounter Object state to '{Status}' but the Chunk status is 'Finished'. A 'Finished' Chunk should not be reactivated and will cause unexpected issues. This is often due to using the 'SetIgnoreChunk' result. You should only ignore chunks that are completely finished to prevent softlocks when trying to end a contract type. Or, it's a bug in your contract type. Check to see if your Trigger Conditionals are set correctly that run 'SetIgnoreChunk' results.");
+          }
+
+          // If the Objective is not active, we should not set it to anything other than 'Active'
           if (encounterGameLogic is ObjectiveGameLogic objectiveGameLogic && objectiveGameLogic.currentObjectiveStatus != ObjectiveStatus.Active) {
-            Main.Logger.LogWarning($"[SetStatusResult] Setting the Objective '{encounterGameLogic.gameObject.name}' Encounter Object state to '{Status}' but the Objective status is not 'Active' (these are different statuses). Current Objective status is '{objectiveGameLogic.currentObjectiveStatus}'. This will mean the Objective will not run.");
-            if (objectiveGameLogic.currentObjectiveStatus == ObjectiveStatus.Ignored) Main.Logger.LogWarning($"Do not set Chunks to 'Ignored' if you want to use them again. This sets all Objectives to 'Ignored'.");
+            Main.LogDeveloperWarning($"[SetStatusResult] Setting the Objective '{encounterGameLogic.gameObject.name}' Encounter Object state to '{Status}' but the Objective status is not 'Active' (these are different statuses). Current Objective status is '{objectiveGameLogic.currentObjectiveStatus}'. This will mean the Objective will not run.");
+
+            // We should not set the Objective to 'Ignored' if it is not active
+            if (objectiveGameLogic.currentObjectiveStatus == ObjectiveStatus.Ignored) Main.LogDeveloperWarning($"Do not set Chunks to 'Ignored' if you want to use them again. This sets all Objectives to 'Ignored'.");
           }
 
           encounterGameLogic.SetState(Status);

--- a/src/Core/Settings/CustomContractTypesSettings.cs
+++ b/src/Core/Settings/CustomContractTypesSettings.cs
@@ -2,6 +2,9 @@ using Newtonsoft.Json;
 
 namespace MissionControl.Config {
   public class CustomContractTypesSettings {
+    [JsonProperty("DeveloperMode")]
+    public bool DeveloperMode { get; set; } = false;
+
     [JsonProperty("Accessibility")]
     public AccessibilitySettings AccessibilitySettings { get; set; } = new AccessibilitySettings();
   }

--- a/src/Core/Settings/SettingsOverride.cs
+++ b/src/Core/Settings/SettingsOverride.cs
@@ -121,6 +121,7 @@ namespace MissionControl.Config {
     public static string CustomData_Search = "CustomData.Search";
     public static string CustomData_SearchType = "CustomData.SearchType";
 
+    public static string CustomContractType_DeveloperMode = "CustomContractTypes.DeveloperMode";
     public static string CustomContractType_Accessibility_AllowCameraShake = "CustomContractTypes.Accessibility.AllowCameraShake";
 
     public static string Misc_LanceSelectionDivergenceOverride_Enable = "Misc.LanceSelectionDivergenceOverride.Enable";
@@ -350,6 +351,7 @@ namespace MissionControl.Config {
     }
 
     public void LoadCustomContractTypes(Settings settings) {
+      if (Has(CustomContractType_DeveloperMode)) settings.CustomContractTypes.DeveloperMode = GetBool(CustomContractType_DeveloperMode);
       if (Has(CustomContractType_Accessibility_AllowCameraShake)) settings.CustomContractTypes.AccessibilitySettings.AllowCameraShake = GetBool(CustomContractType_Accessibility_AllowCameraShake);
     }
 

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -20,6 +20,7 @@ using System.Reflection;
 using MissionControl.Data;
 using MissionControl.Config;
 using MissionControl.Utils;
+using BattleTech.UI;
 
 namespace MissionControl {
   public class Main {
@@ -45,6 +46,14 @@ namespace MissionControl {
 
     public static void LogDebugWarning(string message) {
       if (Main.Settings.DebugMode) Main.Logger.LogWarning(message);
+    }
+
+    public static void LogDeveloperWarning(string message) {
+      Main.Logger.LogWarning(message);
+
+      if (Main.Settings.CustomContractTypes.DeveloperMode) {
+        GenericPopupBuilder.Create(GenericPopupType.Warning, message).AddButton("OK", null, true, null).Render();
+      }
     }
 
     public static void LoadAssetBundles() {

--- a/src/Patches/CustomContractTypes/EncounterObjectGameLogicSetStatePatch.cs
+++ b/src/Patches/CustomContractTypes/EncounterObjectGameLogicSetStatePatch.cs
@@ -6,7 +6,7 @@ using MissionControl.Messages;
 
 namespace MissionControl.Patches {
   [HarmonyPatch(typeof(EncounterObjectGameLogic), "SetState")]
-  public class EncounterObjectGameLogicEncounterStartPatch {
+  public class EncounterObjectGameLogicSetStatePatch {
     static void Prefix(EncounterObjectGameLogic __instance, EncounterObjectStatus status) {
       EncounterObjectStateChangeMessage message = new EncounterObjectStateChangeMessage(__instance.encounterObjectGuid, status);
       UnityGameInstance.BattleTechGame.Combat.MessageCenter.PublishMessage(message);

--- a/src/Patches/CustomContractTypes/PreventStartingStatusOverridingFinishedStatus/EncounterObjectGameLogicEncounterStartPatch.cs
+++ b/src/Patches/CustomContractTypes/PreventStartingStatusOverridingFinishedStatus/EncounterObjectGameLogicEncounterStartPatch.cs
@@ -1,0 +1,18 @@
+using Harmony;
+
+using BattleTech;
+
+namespace MissionControl.Patches {
+  [HarmonyPatch(typeof(EncounterObjectGameLogic), "EncounterStart")]
+  public class EncounterObjectGameLogicEncounterStartPatch {
+    static bool Prefix(EncounterObjectGameLogic __instance) {
+      if (__instance.GetState() == EncounterObjectStatus.Finished) {
+        Main.LogDebug($"[EncounterObjectGameLogicEncounterStartPatch] Preventing '{__instance.gameObject.name}' from setting a starting state because it's state is 'Finished'");
+        __instance.encounterInitialized = true;
+        return false;
+      }
+
+      return true;
+    }
+  }
+}


### PR DESCRIPTION
Adds dev mode that shows specific messages (that I have deemed to be related to logic errors in the contract type) to the developer/modder when dev mode is on for the custom contract type settings.