### PR TITLE
Fix AL objective reveal detection

### DIFF
--- a/src/Core/ContractTypeBuilders/ConditionalBuilder.cs
+++ b/src/Core/ContractTypeBuilders/ConditionalBuilder.cs
@@ -76,6 +76,7 @@ namespace MissionControl.ContractTypeBuilders {
         case "TimerStatus": BuildTimerStatusConditional(conditionalObject); break;
         case "WhoDied": BuildWhoDiedConditional(conditionalObject); break;
         case "WhoKilled": BuildWhoKilledConditional(conditionalObject); break;
+        case "LanceVisibleToPlayer": BuildLanceVisibleToPlayerConditional(conditionalObject); break;
         case "PlayerTonnage": BuildPlayerTonnageConditional(conditionalObject); break;
         default:
           Main.Logger.LogError($"[ChunkTypeBuilder.{contractTypeKey}] No valid conditional was built for '{type}'");
@@ -419,6 +420,22 @@ namespace MissionControl.ContractTypeBuilders {
       } else {
         conditional.killingUnitTagSet = new TagSet();
       }
+
+      conditionalList.Add(new EncounterConditionalBox(conditional));
+    }
+
+    private void BuildLanceVisibleToPlayerConditional(JObject conditionalObject) {
+      Main.LogDebug("[BuildLanceVisibleToPlayerConditional] Building 'LanceVisibleToPlayer' conditional");
+      string targetLanceGuid = conditionalObject.ContainsKey("TargetLanceGuid") ? conditionalObject["TargetLanceGuid"].ToString() : null;
+      if (targetLanceGuid == null && conditionalObject.ContainsKey("LanceGuid")) targetLanceGuid = conditionalObject["LanceGuid"].ToString();
+
+      if (string.IsNullOrEmpty(targetLanceGuid)) {
+        Main.Logger.LogError("[BuildLanceVisibleToPlayerConditional] You have not provided a 'TargetLanceGuid' or 'LanceGuid'.");
+        return;
+      }
+
+      LanceVisibleToPlayerConditional conditional = ScriptableObject.CreateInstance<LanceVisibleToPlayerConditional>();
+      conditional.TargetLanceGuid = targetLanceGuid;
 
       conditionalList.Add(new EncounterConditionalBox(conditional));
     }

--- a/src/Core/EncounterConditionals/LanceVisibleToPlayerConditional.cs
+++ b/src/Core/EncounterConditionals/LanceVisibleToPlayerConditional.cs
@@ -1,0 +1,53 @@
+using BattleTech;
+using BattleTech.Framework;
+
+namespace MissionControl.Conditional {
+  public class LanceVisibleToPlayerConditional : DesignConditional {
+    public string TargetLanceGuid { get; set; }
+
+    public override bool Evaluate(MessageCenterMessage message, string responseName) {
+      base.Evaluate(message, responseName);
+
+      if (string.IsNullOrEmpty(TargetLanceGuid)) {
+        Main.Logger.LogError($"[LanceVisibleToPlayerConditional] TargetLanceGuid is empty. '{responseName}'");
+        return false;
+      }
+
+      VisibilityLevelIncreasedMessage visibilityMessage = message as VisibilityLevelIncreasedMessage;
+      if (visibilityMessage == null) {
+        return false;
+      }
+
+      CombatGameState combat = UnityGameInstance.BattleTechGame?.Combat;
+      if (combat == null) {
+        Main.Logger.LogError($"[LanceVisibleToPlayerConditional] Combat state is unavailable. '{responseName}'");
+        return false;
+      }
+
+      VisibilityLevelAndAttribution visibility = visibilityMessage.VisibilityLevelAndAttribution;
+      if (visibility.SpottingTeamGUID != combat.LocalPlayerTeamGuid) {
+        return false;
+      }
+
+      if (visibility.VisibilityLevel <= VisibilityLevel.None) {
+        return false;
+      }
+
+      AbstractActor targetActor = combat.FindActorByGUID(visibilityMessage.TargetUnitGUID);
+      if (targetActor == null) {
+        return false;
+      }
+
+      if (targetActor.lance == null || string.IsNullOrEmpty(targetActor.lance.GUID)) {
+        return false;
+      }
+
+      if (targetActor.lance.GUID.Contains(TargetLanceGuid)) {
+        Main.LogDebug($"[LanceVisibleToPlayerConditional] Player visibility matches target lance guid '{TargetLanceGuid}'. '{responseName}'");
+        return true;
+      }
+
+      return false;
+    }
+  }
+}

--- a/src/Core/EncounterLogic/BatchedLogic/AddPlayer2LanceWithDestroyObjectiveBatch.cs
+++ b/src/Core/EncounterLogic/BatchedLogic/AddPlayer2LanceWithDestroyObjectiveBatch.cs
@@ -2,6 +2,8 @@ using UnityEngine;
 using System;
 using System.Collections.Generic;
 
+using BattleTech;
+using MissionControl.Conditional;
 using MissionControl.Rules;
 using MissionControl.Trigger;
 using MissionControl.Messages;
@@ -27,7 +29,9 @@ namespace MissionControl.Logic {
         SpawnLogic.LookDirection.AWAY_FROM_TARGET, minDistance, maxDistance));
 
       if (showObjectiveOnLanceDetected) {
-        encounterRules.EncounterLogic.Add(new ShowObjectiveTrigger(MessageCenterMessageType.OnLanceDetected, lanceGuid, objectiveGuid, false));
+        LanceVisibleToPlayerConditional lanceVisibleToPlayerConditional = ScriptableObject.CreateInstance<LanceVisibleToPlayerConditional>();
+        lanceVisibleToPlayerConditional.TargetLanceGuid = lanceGuid;
+        encounterRules.EncounterLogic.Add(new ShowObjectiveTrigger(MessageCenterMessageType.OnVisibilityIncreased, lanceGuid, objectiveGuid, false, lanceVisibleToPlayerConditional));
       }
 
       encounterRules.ObjectReferenceQueue.Add(spawnerName);

--- a/src/Core/EncounterLogic/BatchedLogic/AddTargetLanceWithDestroyObjectiveBatch.cs
+++ b/src/Core/EncounterLogic/BatchedLogic/AddTargetLanceWithDestroyObjectiveBatch.cs
@@ -1,7 +1,11 @@
 using System;
 using System.Collections.Generic;
 
+using BattleTech;
+using UnityEngine;
+
 using MissionControl.Data;
+using MissionControl.Conditional;
 using MissionControl.Rules;
 using MissionControl.Trigger;
 
@@ -27,7 +31,9 @@ namespace MissionControl.Logic {
         SpawnLogic.LookDirection.AWAY_FROM_TARGET, mustBeBeyondDistance, mustBeWithinDistance));
 
       if (showObjectiveOnLanceDetected) {
-        encounterRules.EncounterLogic.Add(new ShowObjectiveTrigger(MessageCenterMessageType.OnLanceDetected, lanceGuid, objectiveGuid, false));
+        LanceVisibleToPlayerConditional lanceVisibleToPlayerConditional = ScriptableObject.CreateInstance<LanceVisibleToPlayerConditional>();
+        lanceVisibleToPlayerConditional.TargetLanceGuid = lanceGuid;
+        encounterRules.EncounterLogic.Add(new ShowObjectiveTrigger(MessageCenterMessageType.OnVisibilityIncreased, lanceGuid, objectiveGuid, false, lanceVisibleToPlayerConditional));
       }
 
       encounterRules.ObjectReferenceQueue.Add(spawnerName);


### PR DESCRIPTION
Fixes #537

Changes generated Additional Lance hidden objectives to reveal from player visibility events instead of broad lance detection events. Also exposes LanceVisibleToPlayer for custom contract type JSONC triggers.